### PR TITLE
OSPB-22: Implement file storage service with UUID-based naming

### DIFF
--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -1,0 +1,40 @@
+import logging
+from logging.config import dictConfig
+import sys
+from .config import settings
+
+# Define log configuration
+log_config = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "default": {
+            "format": "%(asctime)s [%(levelname)s] %(name)s:%(lineno)d - %(message)s",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "DEBUG" if settings.DEBUG else "INFO",
+            "formatter": "default",
+            "stream": sys.stdout,
+        },
+    },
+    "loggers": {
+        "app": {
+            "handlers": ["console"],
+            "level": "DEBUG" if settings.DEBUG else "INFO",
+            "propagate": False
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "DEBUG" if settings.DEBUG else "INFO",
+    },
+}
+
+# Configure logging
+dictConfig(log_config)
+
+# Create logger instance
+logger = logging.getLogger("app")

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -1,0 +1,105 @@
+import os
+import uuid
+from typing import Union
+import logging
+
+# Create logger instance
+logger = logging.getLogger("app.storage")
+
+# Constants
+MAX_FILE_SIZE = 100 * 1024 * 1024  # 100MB in bytes
+ALLOWED_CONTENT_TYPES = {
+    "image/jpeg": ".jpg",
+    "video/mp4": ".mp4"
+}
+STORAGE_DIR = "storage"
+
+def delete_file(filename: str) -> bool:
+    """
+    Delete a file from the storage directory.
+    
+    Args:
+        filename: The name of the file to delete
+        
+    Returns:
+        True if file was successfully deleted or didn't exist, False if deletion failed
+    """
+    try:
+        # Construct full file path
+        file_path = os.path.join(STORAGE_DIR, filename)
+        
+        # Check if file exists
+        if not os.path.exists(file_path):
+            logger.warning(f"Attempted to delete non-existent file: {filename}")
+            return True  # Idempotent behavior - return True if file doesn't exist
+            
+        # Attempt to delete the file
+        os.remove(file_path)
+        logger.info(f"Successfully deleted file: {filename}")
+        return True
+        
+    except OSError as e:
+        logger.error(f"Failed to delete file {filename}: {str(e)}")
+        return False
+    except Exception as e:
+        logger.error(f"Unexpected error while deleting file {filename}: {str(e)}")
+        return False
+
+def save_file(file_data: bytes, content_type: str, file_size: int) -> str:
+    """
+    Save a file to the storage directory with a UUID v4 filename.
+    
+    Args:
+        file_data: The raw bytes of the file to save
+        content_type: The MIME type of the file (e.g., "image/jpeg", "video/mp4")
+        file_size: The size of the file in bytes
+        
+    Returns:
+        The generated filename (including extension)
+        
+    Raises:
+        ValueError: If the content type is not allowed or file size exceeds limit
+        OSError: If there's an error writing the file to disk
+        Exception: For any other unexpected errors
+    """
+    # Validate content type
+    if content_type not in ALLOWED_CONTENT_TYPES:
+        error_msg = f"Unsupported content type: {content_type}. Allowed types: {list(ALLOWED_CONTENT_TYPES.keys())}"
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+    
+    # Validate file size
+    if file_size > MAX_FILE_SIZE:
+        error_msg = f"File size {file_size} bytes exceeds maximum limit of {MAX_FILE_SIZE} bytes"
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+    
+    try:
+        # Generate UUID v4 filename
+        file_uuid = str(uuid.uuid4())
+        file_extension = ALLOWED_CONTENT_TYPES[content_type]
+        filename = f"{file_uuid}{file_extension}"
+        
+        # Ensure storage directory exists
+        os.makedirs(STORAGE_DIR, exist_ok=True)
+        
+        # Construct file path
+        file_path = os.path.join(STORAGE_DIR, filename)
+        
+        # Write file data to disk
+        with open(file_path, "wb") as f:
+            f.write(file_data)
+        
+        # Log successful save
+        logger.info(f"Successfully saved file: {filename} ({file_size} bytes, type: {content_type})")
+        
+        return filename
+        
+    except OSError as e:
+        error_msg = f"Failed to write file to disk: {str(e)}"
+        logger.error(error_msg)
+        raise OSError(error_msg) from e
+    except Exception as e:
+        error_msg = f"Unexpected error while saving file: {str(e)}"
+        logger.error(error_msg)
+        raise Exception(error_msg) from e

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,0 +1,172 @@
+import os
+import uuid
+import pytest
+from unittest.mock import patch, mock_open, MagicMock
+import logging
+
+# Import the storage module
+from app.services.storage import save_file, delete_file
+
+# Test constants
+TEST_JPEG_DATA = b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00'
+TEST_MP4_DATA = b'\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41'
+TEST_TXT_DATA = b'This is a test text file.\n'
+LARGE_FILE_DATA = b'\x00' * (102 * 1024 * 1024)  # 102MB (>100MB limit)
+
+class TestSaveFile:
+    @patch("app.services.storage.uuid.uuid4")
+    @patch("app.services.storage.os.makedirs")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_save_valid_jpeg_file(self, mock_file, mock_makedirs, mock_uuid):
+        # Arrange
+        mock_uuid.return_value = "12345678-1234-4123-8234-123456789abc"
+        expected_filename = "12345678-1234-4123-8234-123456789abc.jpg"
+        expected_filepath = os.path.join("storage", expected_filename)
+
+        # Act
+        result = save_file(TEST_JPEG_DATA, "image/jpeg", len(TEST_JPEG_DATA))
+
+        # Assert
+        assert result == expected_filename
+        mock_makedirs.assert_called_once_with("storage", exist_ok=True)
+        mock_file.assert_called_once_with(expected_filepath, "wb")
+        mock_file().write.assert_called_once_with(TEST_JPEG_DATA)
+        # Verify logger.info was called with expected message
+        with patch("app.services.storage.logger.info") as mock_log:
+            result = save_file(TEST_JPEG_DATA, "image/jpeg", len(TEST_JPEG_DATA))
+            mock_log.assert_called_once()
+
+    @patch("app.services.storage.uuid.uuid4")
+    @patch("app.services.storage.os.makedirs")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_save_valid_mp4_file(self, mock_file, mock_makedirs, mock_uuid):
+        # Arrange
+        mock_uuid.return_value = "abcdef12-3456-4321-b456-abcdef123456"
+        expected_filename = "abcdef12-3456-4321-b456-abcdef123456.mp4"
+        expected_filepath = os.path.join("storage", expected_filename)
+
+        # Act
+        result = save_file(TEST_MP4_DATA, "video/mp4", len(TEST_MP4_DATA))
+
+        # Assert
+        assert result == expected_filename
+        mock_makedirs.assert_called_once_with("storage", exist_ok=True)
+        mock_file.assert_called_once_with(expected_filepath, "wb")
+        mock_file().write.assert_called_once_with(TEST_MP4_DATA)
+        # Verify logger.info was called
+        with patch("app.services.storage.logger.info") as mock_log:
+            result = save_file(TEST_MP4_DATA, "video/mp4", len(TEST_MP4_DATA))
+            mock_log.assert_called_once()
+
+    @patch("app.services.storage.logger.error")
+    def test_save_unsupported_content_type(self, mock_log_error):
+        # Act & Assert
+        with pytest.raises(ValueError, match="Unsupported content type: text/plain"):
+            save_file(TEST_TXT_DATA, "text/plain", len(TEST_TXT_DATA))
+        
+        # Verify error was logged
+        mock_log_error.assert_called_once_with(
+            "Unsupported content type: text/plain. Allowed types: ['image/jpeg', 'video/mp4']"
+        )
+
+    @patch("app.services.storage.logger.error")
+    def test_save_file_size_exceeded(self, mock_log_error):
+        # Act & Assert
+        with pytest.raises(ValueError, match=r"File size \d+ bytes exceeds maximum limit of 104857600 bytes"):
+            save_file(LARGE_FILE_DATA, "image/jpeg", len(LARGE_FILE_DATA))
+        
+        # Verify error was logged
+        mock_log_error.assert_called_once()
+
+    @patch("app.services.storage.os.makedirs")
+    @patch("builtins.open", side_effect=OSError("Permission denied"))
+    @patch("app.services.storage.logger.error")
+    def test_save_file_os_error(self, mock_log_error, mock_open_file, mock_makedirs):
+        # Act & Assert
+        with pytest.raises(OSError, match="Failed to write file to disk: Permission denied"):
+            save_file(TEST_JPEG_DATA, "image/jpeg", len(TEST_JPEG_DATA))
+        
+        # Verify error was logged
+        mock_log_error.assert_called_once_with("Failed to write file to disk: Permission denied")
+
+    @patch("app.services.storage.os.makedirs")
+    @patch("builtins.open", side_effect=Exception("Unexpected error"))
+    @patch("app.services.storage.logger.error")
+    def test_save_file_unexpected_exception(self, mock_log_error, mock_open_file, mock_makedirs):
+        # Act & Assert
+        with pytest.raises(Exception, match="Unexpected error while saving file: Unexpected error"):
+            save_file(TEST_JPEG_DATA, "image/jpeg", len(TEST_JPEG_DATA))
+        
+        # Verify error was logged
+        mock_log_error.assert_called_once_with("Unexpected error while saving file: Unexpected error")
+
+class TestDeleteFile:
+    @patch("app.services.storage.os.path.exists")
+    @patch("app.services.storage.os.remove")
+    @patch("app.services.storage.logger.info")
+    @patch("app.services.storage.logger.warning")
+    def test_delete_existing_file(self, mock_log_warning, mock_log_info, mock_remove, mock_exists):
+        # Arrange
+        mock_exists.return_value = True
+
+        # Act
+        result = delete_file("test.jpg")
+
+        # Assert
+        assert result is True
+        mock_exists.assert_called_once_with(os.path.join("storage", "test.jpg"))
+        mock_remove.assert_called_once_with(os.path.join("storage", "test.jpg"))
+        mock_log_info.assert_called_once_with("Successfully deleted file: test.jpg")
+        mock_log_warning.assert_not_called()
+
+    @patch("app.services.storage.os.path.exists")
+    @patch("app.services.storage.os.remove")
+    @patch("app.services.storage.logger.warning")
+    def test_delete_nonexistent_file(self, mock_log_warning, mock_remove, mock_exists):
+        # Arrange
+        mock_exists.return_value = False
+
+        # Act
+        result = delete_file("nonexistent.jpg")
+
+        # Assert
+        assert result is True
+        mock_exists.assert_called_once_with(os.path.join("storage", "nonexistent.jpg"))
+        mock_remove.assert_not_called()
+        mock_log_warning.assert_called_once_with("Attempted to delete non-existent file: nonexistent.jpg")
+
+    @patch("app.services.storage.os.path.exists")
+    @patch("app.services.storage.os.remove", side_effect=OSError("Permission denied"))
+    @patch("app.services.storage.logger.error")
+    @patch("app.services.storage.logger.warning")
+    def test_delete_file_os_error(self, mock_log_warning, mock_log_error, mock_remove, mock_exists):
+        # Arrange
+        mock_exists.return_value = True
+
+        # Act
+        result = delete_file("test.jpg")
+
+        # Assert
+        assert result is False
+        mock_exists.assert_called_once_with(os.path.join("storage", "test.jpg"))
+        mock_remove.assert_called_once_with(os.path.join("storage", "test.jpg"))
+        mock_log_error.assert_called_once_with("Failed to delete file test.jpg: Permission denied")
+        mock_log_warning.assert_not_called()
+
+    @patch("app.services.storage.os.path.exists")
+    @patch("app.services.storage.os.remove", side_effect=Exception("Unexpected error"))
+    @patch("app.services.storage.logger.error")
+    @patch("app.services.storage.logger.warning")
+    def test_delete_unexpected_exception(self, mock_log_warning, mock_log_error, mock_remove, mock_exists):
+        # Arrange
+        mock_exists.return_value = True
+
+        # Act
+        result = delete_file("test.jpg")
+
+        # Assert
+        assert result is False
+        mock_exists.assert_called_once_with(os.path.join("storage", "test.jpg"))
+        mock_remove.assert_called_once_with(os.path.join("storage", "test.jpg"))
+        mock_log_error.assert_called_once_with("Unexpected error while deleting file test.jpg: Unexpected error")
+        mock_log_warning.assert_not_called()


### PR DESCRIPTION
Implemented the file storage service for osp-backend as described in the task. This includes:
- Saving and deleting media files with UUID v4-based naming in the storage/ directory
- Validation of file types (only image/jpeg and video/mp4) and sizes (max 100MB)
- Comprehensive error handling for invalid inputs and filesystem errors
- Proper logging using the application's logger
- Complete unit test coverage for all functionality

All tests are passing and the implementation meets all acceptance criteria.