### PR TITLE
OSPB-24: Implement trust score calculation service

### DIFF
--- a/app/services/media/service.py
+++ b/app/services/media/service.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from typing import Optional
+import logging
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError, DataError, SQLAlchemyError
+
+from app.db.session import SessionLocal
+from app.models.media import Media
+from app.services.trust import calculate_trust_score
+
+logger = logging.getLogger(__name__)
+
+# Service-level exception for trust score update failures
+class TrustScoreUpdateError(Exception):
+    """Raised when trust score update fails due to business logic or data issues."""
+    pass
+
+
+def update_media_trust_score(db: Session, media_id: int, capture_time: datetime, upload_time: datetime) -> bool:
+    """
+    Update the trust score for a media record in the database.
+    
+    Args:
+        db (Session): Database session
+        media_id (int): ID of the media record
+        capture_time (datetime): When the media was captured
+        upload_time (datetime): When the media was uploaded
+        
+    Returns:
+        bool: True if update was successful, False otherwise
+    """
+    try:
+        # Query the Media table to retrieve the media record
+        media = db.query(Media).filter(Media.id == media_id).first()
+        
+        # If record does not exist, log error and exit gracefully
+        if not media:
+            logger.error(f"Media record not found for id: {media_id}")
+            return False
+            
+        # Validate that capture_time and upload_time are not None
+        if capture_time is None or upload_time is None:
+            logger.warning(
+                f"Missing timestamp(s) for media {media_id}: "
+                f"capture_time={capture_time}, upload_time={upload_time}. Setting trust score to 0."
+            )
+            media.trust_score = 0
+            db.commit()
+            db.refresh(media)
+            return True
+
+        # Use the calculate_trust_score function to compute the score
+        trust_score = calculate_trust_score(capture_time, upload_time)
+        
+        # Update the trust_score field
+        media.trust_score = trust_score
+        
+        # Commit the transaction
+        db.commit()
+        db.refresh(media)
+        
+        logger.info(f"Successfully updated trust score for media {media_id}: {trust_score}")
+        return True
+        
+    except IntegrityError as e:
+        logger.error(f"IntegrityError when updating trust score for media {media_id}: {str(e)}", exc_info=True)
+        db.rollback()
+        return False
+        
+    except DataError as e:
+        logger.error(f"DataError when updating trust score for media {media_id}: {str(e)}", exc_info=True)
+        db.rollback()
+        return False
+        
+    except SQLAlchemyError as e:
+        logger.error(f"SQLAlchemyError when updating trust score for media {media_id}: {str(e)}", exc_info=True)
+        db.rollback()
+        return False
+        
+    except Exception as e:
+        logger.critical(f"Unexpected error when updating trust score for media {media_id}: {str(e)}", exc_info=True)
+        db.rollback()
+        return False

--- a/app/services/trust.py
+++ b/app/services/trust.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
+def calculate_trust_score(capture_time: datetime, upload_time: datetime) -> int:
+    """
+    Calculate the trust score based on the time difference between capture and upload.
+
+    Formula: max(0, 100 - (upload_time - capture_time).total_seconds() / 60)
+    The score decreases by 1 point per minute, starting from 100.
+
+    Args:
+        capture_time (datetime): When the media was captured.
+        upload_time (datetime): When the media was uploaded.
+
+    Returns:
+        int: Calculated trust score (0 to 100), or 0 if inputs are invalid.
+    """
+    # Validate inputs
+    if not isinstance(capture_time, datetime) or not isinstance(upload_time, datetime):
+        logger.warning("Invalid timestamp type: capture_time=%s (%s), upload_time=%s (%s)",
+                      capture_time, type(capture_time).__name__,
+                      upload_time, type(upload_time).__name__)
+        return 0
+
+    if capture_time is None or upload_time is None:
+        logger.warning("Timestamp is None: capture_time=%s, upload_time=%s", capture_time, upload_time)
+        return 0
+
+    if capture_time > upload_time:
+        logger.warning("Capture time is after upload time: %s > %s", capture_time, upload_time)
+        return 0
+
+    try:
+        time_diff_seconds = (upload_time - capture_time).total_seconds()
+        score = max(0, 100 - time_diff_seconds / 60)
+        return int(score)  # Round down
+    except Exception as e:
+        logger.warning("Error calculating trust score: %s", e)
+        return 0

--- a/tests/integration/db/test_media_trust_score.py
+++ b/tests/integration/db/test_media_trust_score.py
@@ -1,0 +1,196 @@
+import pytest
+from datetime import datetime, timezone, timedelta
+from sqlalchemy.orm import Session
+from unittest.mock import patch, MagicMock
+
+from app.db.session import SessionLocal
+from app.db.models import Media, User
+from app.services.media.service import update_media_trust_score, TrustScoreUpdateError
+
+# Helper to create timezone-aware datetime
+def dt(*args):
+    return datetime(*args, tzinfo=timezone.utc)
+
+@pytest.fixture(scope="function")
+def db_session():
+    """Provide a transactional database session for tests."""
+    session = SessionLocal()
+    try:
+        # Begin a transaction
+        session.begin()
+        yield session
+    finally:
+        # Rollback any changes after test
+        session.rollback()
+        session.close()
+
+@pytest.fixture(scope="function")
+def test_user(db_session: Session):
+    user = User(
+        username="testuser",
+        email="testuser@example.com",
+        hashed_password="fakehash",
+        is_active=True
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+@pytest.fixture(scope="function")
+def test_media(db_session: Session, test_user: User):
+    media = Media(
+        capture_time=dt(2023, 1, 1, 12, 0, 0),
+        lat=37.7749,
+        lng=-122.4194,
+        orientation=0.0,
+        file_path="/media/test.jpg",
+        user_id=test_user.id,
+        trust_score=0.0
+    )
+    db_session.add(media)
+    db_session.commit()
+    db_session.refresh(media)
+    return media
+
+class TestUpdateMediaTrustScore:
+    def test_valid_update_successfully_calculates_and_persists_score(self, db_session: Session, test_media: Media):
+        # Given
+        capture_time = dt(2023, 1, 1, 12, 0, 0)
+        upload_time = dt(2023, 1, 1, 12, 5, 0)  # 5 minutes after
+
+        # When
+        success = update_media_trust_score(db_session, test_media.id, capture_time, upload_time)
+
+        # Then
+        assert success is True
+        updated_media = db_session.query(Media).filter(Media.id == test_media.id).first()
+        assert updated_media is not None
+        assert updated_media.trust_score == 95.0
+
+        # Verify log message contains the success info (requires capture_logs fixture or inspection)
+        # We'll rely on the service logging being tested via caplog in unit context.
+        # In integration we check behavior rather than logs.
+
+    def test_large_delay_yields_zero_score(self, db_session: Session, test_media: Media):
+        # Given
+        capture_time = dt(2023, 1, 1, 12, 0, 0)
+        upload_time = dt(2023, 1, 1, 15, 20, 0)  # 200 minutes later
+
+        # When
+        success = update_media_trust_score(db_session, test_media.id, capture_time, upload_time)
+
+        # Then
+        assert success is True
+        updated_media = db_session.query(Media).filter(Media.id == test_media.id).first()
+        assert updated_media.trust_score == 0.0
+
+    def test_equal_timestamps_yields_max_score(self, db_session: Session, test_media: Media):
+        # Given
+        capture_time = dt(2023, 1, 1, 12, 0, 0)
+        upload_time = dt(2023, 1, 1, 12, 0, 0)
+
+        # When
+        success = update_media_trust_score(db_session, test_media.id, capture_time, upload_time)
+
+        # Then
+        assert success is True
+        updated_media = db_session.query(Media).filter(Media.id == test_media.id).first()
+        assert updated_media.trust_score == 100.0
+
+    def test_none_timestamps_sets_score_to_zero_with_warning_log(self, db_session: Session, test_media: Media, caplog):
+        # Given: Simulate missing capture time
+        capture_time = None
+        upload_time = dt(2023, 1, 1, 12, 0, 0)
+
+        # When
+        with caplog.at_level("WARNING"):
+            success = update_media_trust_score(db_session, test_media.id, capture_time, upload_time)
+
+        # Then
+        assert success is True
+        updated_media = db_session.query(Media).filter(Media.id == test_media.id).first()
+        assert updated_media.trust_score == 0.0
+        assert "Missing timestamp(s)" in caplog.text
+
+    def test_database_error_handled_gracefully(self, db_session: Session, test_media: Media):
+        # Given
+        capture_time = dt(2023, 1, 1, 12, 0, 0)
+        upload_time = dt(2023, 1, 1, 12, 5, 0)
+
+        # Mock db.query to raise an exception
+        with patch.object(db_session, "query", side_effect=Exception("DB connection lost")):
+            # When
+            success = update_media_trust_score(db_session, test_media.id, capture_time, upload_time)
+
+            # Then
+            assert success is False
+
+    def test_media_record_not_found_returns_false(self, db_session: Session):
+        # Given
+        non_existent_id = 99999
+        capture_time = dt(2023, 1, 1, 12, 0, 0)
+        upload_time = dt(2023, 1, 1, 12, 5, 0)
+
+        # When
+        with patch("app.services.media.service.logger") as mock_logger:
+            success = update_media_trust_score(db_session, non_existent_id, capture_time, upload_time)
+
+        # Then
+        assert success is False
+        mock_logger.error.assert_called_with(f"Media record not found for id: {non_existent_id}")
+
+    def test_unexpected_exception_rolls_back_and_returns_false(self, db_session: Session, test_media: Media):
+        # Given
+        capture_time = dt(2023, 1, 1, 12, 0, 0)
+        upload_time = dt(2023, 1, 1, 12, 5, 0)
+
+        # Patch within Media instance query to force failure after retrieval
+        with patch.object(db_session.__class__, "commit", side_effect=Exception("Disk full")):
+            with patch("app.services.media.service.logger") as mock_logger:
+                # When
+                success = update_media_trust_score(db_session, test_media.id, capture_time, upload_time)
+
+                # Then
+                assert success is False
+                mock_logger.critical.assert_called()
+                # Verify rollback occurred conceptually (we can't directly check SQL state)
+                db_session.rollback.assert_called()
+
+    def test_integrity_error_rolls_back_and_returns_false(self, db_session: Session, test_media: Media):
+        # Given
+        from sqlalchemy.exc import IntegrityError
+        capture_time = dt(2023, 1, 1, 12, 0, 0)
+        upload_time = dt(2023, 1, 1, 12, 5, 0)
+
+        # Simulate IntegrityError on commit
+        with patch.object(db_session.__class__, "commit", side_effect=IntegrityError(None, None, None)):
+            with patch("app.services.media.service.logger") as mock_logger:
+                # When
+                success = update_media_trust_score(db_session, test_media.id, capture_time, upload_time)
+
+                # Then
+                assert success is False
+                mock_logger.error.assert_called_with(
+                    f"IntegrityError when updating trust score for media {test_media.id}: (builtins.NoneType) None"
+                )
+                db_session.rollback.assert_called()
+        
+    def test_data_error_rolls_back_and_returns_false(self, db_session: Session, test_media: Media):
+        # Given
+        from sqlalchemy.exc import DataError
+        capture_time = dt(2023, 1, 1, 12, 0, 0)
+        upload_time = dt(2023, 1, 1, 12, 5, 0)
+
+        # Simulate DataError on commit
+        with patch.object(db_session.__class__, "commit", side_effect=DataError(None, None, None)):
+            with patch("app.services.media.service.logger") as mock_logger:
+                # When
+                success = update_media_trust_score(db_session, test_media.id, capture_time, upload_time)
+
+                # Then
+                assert success is False
+                mock_logger.error.assert_called_with(
+                    f"DataError when updating trust score for media {test_media.id}: (builtins.NoneType) None"
+                )
+                db_session.rollback.assert_called()

--- a/tests/unit/services/test_trust.py
+++ b/tests/unit/services/test_trust.py
@@ -1,0 +1,70 @@
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, MagicMock
+from app.services.trust import calculate_trust_score
+
+# Helper to create timezone-aware datetime
+def dt(*args):
+    return datetime(*args, tzinfo=timezone.utc)
+
+class TestCalculateTrustScore:
+    def test_valid_small_delay(self):
+        capture = dt(2023, 1, 1, 12, 0, 0)
+        upload = dt(2023, 1, 1, 12, 5, 0)  # 5 minutes later
+        score = calculate_trust_score(capture, upload)
+        assert score == 95
+
+    def test_large_delay_yields_zero(self):
+        capture = dt(2023, 1, 1, 12, 0, 0)
+        upload = dt(2023, 1, 1, 15, 20, 0)  # 200 minutes later
+        score = calculate_trust_score(capture, upload)
+        assert score == 0
+
+    def test_equal_timestamps_yields_max(self):
+        capture = dt(2023, 1, 1, 12, 0, 0)
+        upload = dt(2023, 1, 1, 12, 0, 0)
+        score = calculate_trust_score(capture, upload)
+        assert score == 100
+
+    def test_none_timestamps_returns_zero_and_logs_warning(self, caplog):
+        with caplog.at_level("WARNING"):
+            score = calculate_trust_score(None, dt(2023, 1, 1, 12, 0, 0))
+            assert score == 0
+            assert "Timestamp is None" in caplog.text
+
+        caplog.clear()
+
+        with caplog.at_level("WARNING"):
+            score = calculate_trust_score(dt(2023, 1, 1, 12, 0, 0), None)
+            assert score == 0
+            assert "Timestamp is None" in caplog.text
+
+    def test_invalid_type_timestamps_returns_zero_and_logs_warning(self, caplog):
+        with caplog.at_level("WARNING"):
+            score = calculate_trust_score("not-a-datetime", dt(2023, 1, 1, 12, 0, 0))
+            assert score == 0
+            assert "Invalid timestamp type" in caplog.text
+
+        caplog.clear()
+
+        with caplog.at_level("WARNING"):
+            score = calculate_trust_score(dt(2023, 1, 1, 12, 0, 0), 123)
+            assert score == 0
+            assert "Invalid timestamp type" in caplog.text
+
+    def test_capture_after_upload_returns_zero_and_logs_warning(self, caplog):
+        capture = dt(2023, 1, 1, 13, 0, 0)
+        upload = dt(2023, 1, 1, 12, 0, 0)  # earlier upload
+        with caplog.at_level("WARNING"):
+            score = calculate_trust_score(capture, upload)
+            assert score == 0
+            assert "Capture time is after upload time" in caplog.text
+
+    def test_negative_time_diff_exception_handled_gracefully(self, caplog):
+        # This case is already handled by capture > upload, but testing robustness
+        capture = dt(2023, 1, 1, 12, 0, 5)
+        upload = dt(2023, 1, 1, 12, 0, 0)
+        with caplog.at_level("WARNING"):
+            score = calculate_trust_score(capture, upload)
+            assert score == 0
+            assert "Capture time is after upload time" in caplog.text


### PR DESCRIPTION
Implemented trust score calculation service as per Epic section 3.1. Added calculate_trust_score function in services/trust.py that implements the formula max(0, 100 - (upload_time - capture_time).total_seconds() / 60). Created update_media_trust_score service in media/service.py to update the Media table with proper error handling for invalid timestamps and database errors. Included comprehensive unit and integration tests covering all acceptance criteria including edge cases, error scenarios, and database failure conditions. All implemented functionality includes appropriate logging using the global logger instance.